### PR TITLE
Removed the Publish artefacts which was left over by mistake

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,8 +66,3 @@ steps:
     codeCoverageTool: 'cobertura'
     summaryFileLocation: '$(modulePath)/reports/coverage.xml'
     reportDirectory: '$(modulePath)/reports/'
-
-- task: PublishPipelineArtifact@0
-  inputs:
-    artifactName: 'Test Reports'
-    targetPath: '$(modulePath)/reports/'


### PR DESCRIPTION
I was using this task mostly to troubleshoot during development. IN the final checkin, we do not want to upload the test report using this method as there are dedicated report views available in AzDev.