### PR TITLE
fix to ignore dot files to copy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ steps:
     mkdir -p '$(GOPATH)/pkg'
     mkdir -p '$(modulePath)'
     shopt -s extglob
+    shopt -s dotglob
     mv !(gopath) '$(modulePath)'
     echo '##vso[task.prependpath]$(GOBIN)'
     echo '##vso[task.prependpath]$(GOROOT)/bin'


### PR DESCRIPTION
This PR is related this issue. https://developercommunity.visualstudio.com/content/problem/420440/go-template-ignore-dot-files.html

The current go template ignore the dot files. like `.foo`. It copys Go files however, it doesn't work if they require the dot files. 

Since I'm not sure if you have some intent for not using dotglob, I just want to share the issue and hopefully contribute it.